### PR TITLE
chore: bump GHA actions off Node 20 (SCICO-1260)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       TERM: xterm
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Build with sanitizers
         run: make germline OPT="-std=c++17 -O1 -g -fsanitize=address,undefined -I include"
       - name: Test with sanitizers
@@ -39,7 +39,7 @@ jobs:
           VERSION="$(bin/germline -version)"
           echo "version=${VERSION/version /v}" >> $GITHUB_OUTPUT
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3.0.0
         if: inputs.make_release
         with:
           files: |


### PR DESCRIPTION
Cleanup pass against [SCICO-1260](https://embarkvet.atlassian.net/browse/SCICO-1260) to remove residual Node 20 / Node 16 GHA action references.

## Bumps applied

| Action | From | To |
|---|---|---|
| `actions/checkout` | `v4` | `v6` |
| `softprops/action-gh-release` | `v2` | `v3.0.0` |

---
🤖 via Claude Code

[SCICO-1260]: https://embarkvet.atlassian.net/browse/SCICO-1260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ